### PR TITLE
[fix] PAT token -> github token 수정

### DIFF
--- a/.github/workflows/wemo-ci.yml
+++ b/.github/workflows/wemo-ci.yml
@@ -84,4 +84,4 @@ jobs:
 
           base: ${{ github.ref == 'dev' && 'main' || 'dev' }}
           branch: ${{ github.ref }}
-          token: ${{ secrets.ACCESS_TOKEN_FOR_CI }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wemo-ci.yml
+++ b/.github/workflows/wemo-ci.yml
@@ -51,6 +51,9 @@ jobs:
     needs: run-test-and-build
     name: Create PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Get Codes
         uses: actions/checkout@v4


### PR DESCRIPTION
## 📝 작업 내용
- PAT token -> github token 수정 

- PR을 생성할때 사용하는 토큰을 사용합니다. 다만 사용하는 토큰 제가 발급받은 PAT(personal access token)이라 
작성자가 작업자가 아닌 저의 이름으로 올라가고 있네요 

- GITHUB_TOKEN을 사용한다면 작업자의 이름으로 올라간다고 합니다. 다만 레포 세팅을 수정해야하는데 권한이 없는건지 변경이 불가능하네요
오후에 다은님 오시면 수정해보겠습니다