### PR TITLE
[GHA] 버셀을 활용한 CD 구축 및 PR 내용 초기화 CI 수정

### DIFF
--- a/.github/workflows/wemo-cd.yml
+++ b/.github/workflows/wemo-cd.yml
@@ -1,0 +1,30 @@
+name: WeMo CD
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+      - name: creates output
+        run: sh ./build.sh
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          source-directory: 'output'
+          destination-github-username: yunsunglee2
+          destination-repository-name: WeMo-FE
+          user-email: ${{ secrets.YUNSUNG_ACCOUNT_EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/.github/workflows/wemo-ci.yml
+++ b/.github/workflows/wemo-ci.yml
@@ -78,13 +78,13 @@ jobs:
             <!-- 공유하고 싶은 사진이 있다면 올려주세요! -->
 
             ## ✅ 리뷰 요구사항 (선택)
-            - 확인해주세요!:
+            - 확인해주세요:
               - [ ] 요구사항1
               - [ ] 요구사항2
               - [ ] 요구사항3
 
-            > <!-- 리뷰어가 확인했으면 하는 내용을 중점으로 작성해주세요. -->
-
           base: ${{ github.ref == 'dev' && 'main' || 'dev' }}
           branch: ${{ github.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          delete-branch: false  # 기존 브랜치 삭제 방지
+          draft: false  # 기존 PR 내용을 유지

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+// ./build.sh 
+
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./WeMo-FE/* ./output
+cp -R ./output ./WeMo-FE/


### PR DESCRIPTION
## 📝 작업 내용
- main에서 push 발생하면 오가니 제이션 main -> 포크한 개인 레포 main -> 버셀 배포 CD 구축 
- 기존 PR 내용 초기화되는 버그 수정

## 📸 스크린샷 (선택)

```
+------------------------+
| Push to `main` branch |
+------------------------+
          │
          ▼
+-----------------------------+
| Run GitHub Actions Workflow |
+-----------------------------+
          │
          ▼
        (생략)
          │
          ▼
+------------------------+
| Run `build.sh` Script |
+------------------------+
          │
          ▼
+-------------------------------+
| Push `output` to Another Repo |
| (yunsunglee2/WeMo-FE `main`)  |
+-------------------------------+
          │
          ▼
+----------------------------+
| Confirm Deployment Success |
+----------------------------+
          │
          ▼
      ✅ Done ✅
```


## 🫡 리뷰 요구사항 (선택)

> <!-- 리뷰어가 확인했으면 하는 내용을 중점으로 작성해주세요. -->
