### PR TITLE
[Feature] axios interceptor 에러 핸들링 / oAuth 중복 요청 수정

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,10 +1,10 @@
 import axios from 'axios';
 import { API_PATHS } from '@/constants/apiPath';
-// import store from '@/redux/store';
-// import { logout } from '@/redux/authReducers';
+import store from '@/redux/store';
+import { logout } from '@/redux/authReducers';
 
 const {
-  AUTH: { REFRESH_TOKEN },
+  AUTH: { REFRESH_TOKEN, SIGNOUT },
 } = API_PATHS;
 
 const baseURL = process.env.NEXT_PUBLIC_BASE_URL;
@@ -19,6 +19,7 @@ const instance = axios.create({
 
 // 무한 루프 예방 변수
 let isRefreshing = false;
+const logoutInitiatedKey = 'logoutInitiated';
 
 instance.interceptors.response.use(
   (response) => response,
@@ -35,24 +36,35 @@ instance.interceptors.response.use(
       isRefreshing = true; // 무한 루프 예방
 
       try {
+        console.log('🔄 리프레시 토큰 요청 중...');
         await instance.post(REFRESH_TOKEN);
+        console.log('✅ 리프레시 토큰 갱신 성공');
         isRefreshing = false;
         return instance(originalRequest); // 실패한 요청 재시도
-      } catch (error: unknown) {
-        if (axios.isAxiosError(error)) {
-          console.error(error.response?.data.message);
-        } else if (error instanceof Error) {
-          console.error(error.message);
-        } else {
-          console.error('Unexpected error:', error);
+      } catch (refreshError: unknown) {
+        // console.error('❌ 리프레시 토큰 갱신 실패', error);
+
+        if (!localStorage.getItem(logoutInitiatedKey)) {
+          localStorage.setItem(logoutInitiatedKey, 'true'); // 플래그 설정
+
+          // Case 2: 리프레시 토큰 만료 -> 로그아웃 처리
+          try {
+            await instance.post(SIGNOUT); // Attempt to sign out
+            console.log('✅ SIGNOUT successful');
+          } catch (signoutError: unknown) {
+            console.warn(
+              'SIGNOUT failed with error',
+              signoutError.response?.status,
+            );
+          } finally {
+            // Always execute this block, regardless of SIGNOUT success or failure
+            store.dispatch(logout()); // Clear global user information
+            alert('세션이 만료되었습니다. 다시 로그인 해주세요.');
+            window.location.href = '/start';
+          }
         }
 
-        // Case 2: 리프레시 토큰 만료 -> 로그아웃 처리
-        // await instance.post(SIGNOUT);
-        // alert('세션이 만료되었습니다.');
-        // store.dispatch(logout()); // ✅ 전역객체에도 유저 정보 초기화
-        // window.location.href = '/start';
-        // return Promise.reject(error);
+        return Promise.reject(refreshError);
       }
     }
 

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { isAxiosError } from 'axios';
 import { API_PATHS } from '@/constants/apiPath';
 import store from '@/redux/store';
 import { logout } from '@/redux/authReducers';
@@ -52,10 +52,14 @@ instance.interceptors.response.use(
             await instance.post(SIGNOUT); // Attempt to sign out
             console.log('✅ SIGNOUT successful');
           } catch (signoutError: unknown) {
-            console.warn(
-              'SIGNOUT failed with error',
-              signoutError.response?.status,
-            );
+            if (isAxiosError(signoutError)) {
+              console.error(
+                'SIGNOUT failed with error',
+                signoutError.response?.status,
+              );
+            } else {
+              console.error('SIGNOUT failed with unknown error', signoutError);
+            }
           } finally {
             // Always execute this block, regardless of SIGNOUT success or failure
             store.dispatch(logout()); // Clear global user information

--- a/src/components/gnb/footer/index.tsx
+++ b/src/components/gnb/footer/index.tsx
@@ -1,14 +1,16 @@
 import { hideGnbFooterRoutes, menuItems } from '@/constants/gnb';
 import GNBItem from '../item';
 import { useRouter } from 'next/router';
-import { GNBProps } from '../header';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/store';
 
 // GNB 레이아웃 컴포넌트에서 렌더링 되는 footer 컴포넌트입니다.
 // 페이지마다 출력이 달라 path를 조회해 조건부 렌더링 합니다.
 // 로그인 여부를 전역객체에서 조회해 조건부 렌더링 합니다.
 // 상위 컴포넌트로 부터 유저 정보 응답을 내려받아 라우팅 합니다.
-function GNBFooter({ response }: GNBProps) {
+function GNBFooter() {
   const router = useRouter();
+  const { isLoggedIn, user } = useSelector((state: RootState) => state.auth);
 
   const showGnbFooter = hideGnbFooterRoutes.includes(router.pathname);
   return (
@@ -20,10 +22,8 @@ function GNBFooter({ response }: GNBProps) {
               <GNBItem key={item.key} name={item.name} path={item.path} />
             ))}
             <GNBItem
-              name={response?.success ? '마이페이지' : '로그인'}
-              path={
-                response?.success ? `/user/${response.data.nickname}` : '/start'
-              }
+              name={isLoggedIn ? '마이페이지' : '로그인'}
+              path={isLoggedIn ? `/user/${user?.nickname}` : '/start'}
             />
           </ul>
         </footer>

--- a/src/components/gnb/header/index.tsx
+++ b/src/components/gnb/header/index.tsx
@@ -4,22 +4,16 @@ import logo from '@/assets/images/title.png';
 import GNBItem from '../item';
 import { useRouter } from 'next/router';
 import { hideGnbHeaderRoutes } from '@/constants/gnb';
-import { UserData } from '@/types/mypageType';
-
-export interface GNBProps {
-  response: {
-    data: UserData;
-    message: string;
-    success: boolean;
-  };
-}
+import { useSelector } from 'react-redux';
+import { RootState } from '@/redux/store';
 
 // GNB 레이아웃 컴포넌트에서 렌더링 되는 header 컴포넌트입니다.
 // 페이지마다 출력이 달라 path를 조회해 조건부 렌더링 합니다.
 // 로그인 여부를 전역객체에서 조회해 조건부 렌더링 합니다.
 // 상위 컴포넌트로 부터 유저 정보 응답을 내려받아 라우팅 합니다.
-function GNBHeader({ response }: GNBProps) {
+function GNBHeader() {
   const router = useRouter();
+  const { isLoggedIn, user } = useSelector((state: RootState) => state.auth);
   const showGnbHeader = hideGnbHeaderRoutes.includes(router.pathname);
 
   return (
@@ -51,12 +45,8 @@ function GNBHeader({ response }: GNBProps) {
                       isHeader
                     />
                     <GNBItem
-                      name={response?.success ? '마이페이지' : '로그인'}
-                      path={
-                        response?.success
-                          ? `/user/${response.data.nickname}`
-                          : '/start'
-                      }
+                      name={isLoggedIn ? '마이페이지' : '로그인'}
+                      path={isLoggedIn ? `/user/${user?.nickname}` : '/start'}
                       isHeader
                     />
                   </ul>

--- a/src/components/shared/layout/GNB.tsx
+++ b/src/components/shared/layout/GNB.tsx
@@ -10,16 +10,16 @@ const noto = Noto_Sans_KR({
 });
 
 function GNB({ children }: PropsWithChildren) {
-  const { isLoading, response } = useAuth();
+  const { isLoading } = useAuth();
 
   if (isLoading) {
     return <Spinner />;
   }
   return (
     <main className={noto.className}>
-      <GNBHeader response={response} />
+      <GNBHeader />
       {children}
-      <GNBFooter response={response} />
+      <GNBFooter />
     </main>
   );
 }

--- a/src/components/shared/layout/GNB.tsx
+++ b/src/components/shared/layout/GNB.tsx
@@ -3,18 +3,13 @@ import { Noto_Sans_KR } from 'next/font/google';
 import GNBHeader from '@/components/gnb/header';
 import GNBFooter from '@/components/gnb/footer';
 import useAuth from '@/hooks/useAuth';
-import Spinner from '@/components/gnb/spinner';
 
 const noto = Noto_Sans_KR({
   subsets: ['latin'],
 });
 
 function GNB({ children }: PropsWithChildren) {
-  const { isLoading } = useAuth();
-
-  if (isLoading) {
-    return <Spinner />;
-  }
+  useAuth();
   return (
     <main className={noto.className}>
       <GNBHeader />

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -24,6 +24,8 @@ function useAuth() {
     queryKey: ['auth'],
     queryFn: fetchUserInfo,
     retry: false,
+    gcTime: 0,
+    staleTime: 0,
   });
 
   useEffect(() => {

--- a/src/hooks/useOAuthLogin.tsx
+++ b/src/hooks/useOAuthLogin.tsx
@@ -1,7 +1,7 @@
 import instance from '@/api/axiosInstance';
 import { useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { login } from '@/redux/authReducers';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDispatch } from 'react-redux';
@@ -11,35 +11,36 @@ function useOAuthLogin(platform: string) {
   const queryClient = useQueryClient();
   const dispatch = useDispatch();
   const router = useRouter();
-  const [isFetched, setIsFetched] = useState(false); // ✅ 2번 요청 보내는 것 방지
-  // 리다이렉트 페이지 쿼리 스트링에는 구글서버에서 보내주는 authcode가 담겨져있습니다.
-  const authCode = searchParams.get('code');
-  useEffect(() => {
-    if (!authCode || isFetched) {
-      return;
-    } // ✅ authCode가 없거나 이미 요청을 보냈다면 실행하지 않음
+  const isFetched = useRef(false); // ✅ invalidateQueries로 인한 리렌더링 -> 재요청 보내는 것 방지를 위한 함수
 
-    setIsFetched(true); // ✅ 요청 전에 상태 업데이트
-    const fetchAuthCode = async () => {
-      try {
-        //authcode를 쿼리스트링으로 담아서 리소스 서버에 요청을 보냅니다.
-        // 서버에서는 전달받은 authcode를 갖고 googleAutherizationSever에서 accessToken을 발급 받아 내려줍니다.
-        // 또한 서버에서는 accessToken을 활용해 사용자 정보를 구글서버에서 받아와 유저 정보를 저장합니다.
-        const response = await instance.get(
-          `/login/oauth2/callback/${platform}?code=${authCode}`,
-        );
-        const { success } = response.data;
-        // 요청이 성공해 accessToken이 클라이언트에 잘 전달됐다면 invalidateQueries를 통해 GNB 컴포넌트에서 useAuth 함수 안에 쿼리를 실행합니다.
-        if (success) {
-          dispatch(login());
-          router.replace('/plans');
-          queryClient.invalidateQueries({ queryKey: ['auth'] });
-        }
-      } catch (error) {
-        console.error(`${platform} oAuth Error fetching data:`, error);
-        throw error;
+  const authCode = searchParams.get('code'); // 리다이렉트 페이지 쿼리 스트링에는 구글서버에서 보내주는 authcode가 담겨져있습니다.
+
+  const fetchAuthCode = async () => {
+    try {
+      //authcode를 쿼리스트링으로 담아서 리소스 서버에 요청을 보냅니다.
+      // 서버에서는 전달받은 authcode를 갖고 googleAutherizationSever에서 accessToken을 발급 받아 내려줍니다.
+      // 또한 서버에서는 accessToken을 활용해 사용자 정보를 구글서버에서 받아와 유저 정보를 저장합니다.
+      const response = await instance.get(
+        `/login/oauth2/callback/${platform}?code=${authCode}`,
+      );
+      const { success } = response.data;
+      // 요청이 성공해 accessToken이 클라이언트에 잘 전달됐다면 invalidateQueries를 통해 GNB 컴포넌트에서 useAuth 함수 안에 쿼리를 실행합니다.
+      if (success) {
+        dispatch(login());
+        router.replace('/plans');
+        queryClient.invalidateQueries({ queryKey: ['auth'] });
       }
-    };
+    } catch (error) {
+      console.error(`${platform} oAuth Error fetching data:`, error);
+      throw error;
+    }
+  };
+
+  useEffect(() => {
+    if (!authCode || !!isFetched.current) return; // ✅ authCode가 없거나 이미 요청을 보냈다면 실행하지 않음
+
+    isFetched.current = true; // ✅ 요청 전에 상태 업데이트
+    router.replace(router.pathname); // ✅ 스트릭트 모드 마운트, 언마운트 동작에 의한 재요청 방지를 위한 코드
     fetchAuthCode();
   }, [authCode]);
 }

--- a/src/hooks/useOAuthLogin.tsx
+++ b/src/hooks/useOAuthLogin.tsx
@@ -14,12 +14,8 @@ function useOAuthLogin(platform: string) {
   const [isFetched, setIsFetched] = useState(false); // ✅ 2번 요청 보내는 것 방지
   // 리다이렉트 페이지 쿼리 스트링에는 구글서버에서 보내주는 authcode가 담겨져있습니다.
   const authCode = searchParams.get('code');
-  console.log(authCode, '---authCode---');
-  console.log(isFetched, '---isFetched---');
   useEffect(() => {
-    console.log('유즈 이펙트 실행 중...');
     if (!authCode || isFetched) {
-      console.log('Skipping fetch - authCode missing or already fetched');
       return;
     } // ✅ authCode가 없거나 이미 요청을 보냈다면 실행하지 않음
 
@@ -46,13 +42,6 @@ function useOAuthLogin(platform: string) {
     };
     fetchAuthCode();
   }, [authCode]);
-
-  useEffect(() => {
-    console.log('---마운트---');
-    return () => {
-      console.log('---언마운트---');
-    };
-  }, []);
 }
 
 export default useOAuthLogin;


### PR DESCRIPTION
## 📝 1. axios interceptor 에러 핸들링
[엑세스 토큰 만료]
- 액세스 토큰 만료 -> 401에러 인터셉터 캐치 -> 리프레시 토큰을 활용해 토큰 재발급 -> 기존 실패 요청 재시도

[리프레시 토큰 만료]
- 토큰 재발급 실패 -> 리프레시 토큰 만료로 인식 -> 서버에 로그아웃 요청 -> 전역객체 유저정보 초기화 / startPage로 이동

## 🫡 리뷰 요구사항
- 현재 생성한 axios instance에 등록한 interceptor이기 때문에 instance를 사용해 서버에 요청을 보내지 않으면 에러를 캐치하지 않습니다. 그냥 axios를 사용하고 계신분들은 axios instance로 수정 부탁드려요
 
- 액세스 토큰과 리프레시 토큰 만료 시간에 대해 의견을 남겨주세요!

- 추후 도메인 수정으로 인해 동작이 영향을 받을 수 있습니다.

## 📝 토큰 관련 시나리오
<img width="747" alt="image" src="https://github.com/user-attachments/assets/76a7d481-5ebb-4e38-ac4d-682eec5d6eb7" />

------------------------------------

## 📝  2. oAuth 중복 요청 에러 
[invalidateQueries로 인한 리렌더링]
- invalidateQueries가 GNB 컴포넌트의 리렌더링을 트리거합니다. 
- GNB 컴포넌트는 레이아웃 컴포넌트이기 때문에 현재 화면에서 자식 컴포넌트가 리렌더링 됩니다.
- 이로 인해 중복으로 서버에 요청이 보내집니다.
[해결방법] 
- useRef를 사용하여 리렌더링 되어도 유지되는 값인 DOM을 이용해 조건문으로 실행을 막았음.

[개발환경 strictMode로 인한 마운트,언마운트]
- 현재 개발 환경이라 컴포넌트가 마운트, 언마운트 됨.
- 이로 인해서 url 쿼리에 실려 있는 구글/카카오톡/네이버 1회용 authCode(REST API 방식 oAuth로그인)로 재요청을 보내 500에러 또는 400에러가 발생함.
[해결방법]
- authCode를 취득하고 서버에 요청을 보내기전에 pathname 뒤에 쿼리를 모두 날림.
- 다시 마운트가 되어 같은 동작을 수행하려 해도 url 쿼리에서 authCode를 취득하지 못함 
- 조건문에 걸려 재요청 보내지 않음.