### PR TITLE
[Refac] 일정 목록 페이지 SSR initialData Props -> 리액트 쿼리 hydration API 전환

### DIFF
--- a/pages/plans/[id].tsx
+++ b/pages/plans/[id].tsx
@@ -1,5 +1,5 @@
 import { PlanDetail } from '@/pages/app/plans/[id]';
-import fetchPlanDetailSSR from './ssr/plans';
+import getPlanDetailSSR from './api/getPlanDetailSSR';
 import { QUERY_KEY } from '@/shared/constants/queryKey';
 import {
   dehydrate,
@@ -32,7 +32,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const idNum = parseInt(id as string);
   await queryClient.prefetchQuery({
     queryKey: QUERY_KEY.planDetail(idNum),
-    queryFn: () => fetchPlanDetailSSR(idNum, cookie),
+    queryFn: () => getPlanDetailSSR(idNum, cookie),
   });
 
   return {

--- a/pages/plans/api/getPlanDetailSSR.ts
+++ b/pages/plans/api/getPlanDetailSSR.ts
@@ -3,7 +3,7 @@ import { PlanDetailResponse } from '@/shared/types/api/plan';
 import { ssrInstance } from '@/shared/utils/axiosSsr';
 import axios from 'axios';
 
-const fetchPlanDetailSSR = async (planId: number, cookie?: string) => {
+const getPlanDetailSSR = async (planId: number, cookie?: string) => {
   //SSR 전용 instance에 쿠키를 전달하여 생성합니다.
   const newInstance = ssrInstance(cookie);
   if (isNaN(planId)) return;
@@ -21,4 +21,4 @@ const fetchPlanDetailSSR = async (planId: number, cookie?: string) => {
   }
 };
 
-export default fetchPlanDetailSSR;
+export default getPlanDetailSSR;

--- a/pages/plans/api/getPlansSSR.ts
+++ b/pages/plans/api/getPlansSSR.ts
@@ -1,0 +1,32 @@
+import { ssrInstance } from '@/shared/utils/axiosSsr';
+import { PlanListResponse } from '@/shared/types/plans';
+
+export interface getPlansSSRProps {
+  cookie?: string;
+  isLoggedIn: boolean;
+  sortParam?: string;
+  categoryParam?: number;
+  cursorParam?: string;
+}
+
+async function getPlansSSR({
+  cookie = '',
+  isLoggedIn = false,
+  sortParam = '',
+  categoryParam = 1,
+  cursorParam = '',
+}: getPlansSSRProps) {
+  const res = await ssrInstance(cookie).get<PlanListResponse>(
+    `/api/plans?size=10&sort=${sortParam}&categoryId=${categoryParam}&cursor=${cursorParam}`,
+    {
+      headers: isLoggedIn ? { Cookie: cookie } : {},
+      withCredentials: isLoggedIn,
+    },
+  );
+
+  const data = res.data;
+
+  return data;
+}
+
+export default getPlansSSR;

--- a/pages/plans/index.tsx
+++ b/pages/plans/index.tsx
@@ -1,19 +1,23 @@
-import { Home } from '@/pages/app/plans';
 import type { GetServerSideProps } from 'next';
-import { ssrInstance } from '@/shared/utils/axiosSsr';
-import { PlanDataWithCategory, PlanListResponse } from '@/shared/types/plans';
+import {
+  dehydrate,
+  DehydratedState,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query';
+
+import { Home } from '@/pages/app/plans';
+import getPlans from '@/pages/app/plans/api/getPlans';
 
 interface HomeProps {
-  initialPlans: PlanDataWithCategory[];
-  initialCursor: number | null;
+  dehydratedState: DehydratedState;
 }
 
-export default function HomePage(props: HomeProps) {
+export default function HomePage({ dehydratedState }: HomeProps) {
   return (
-    <Home
-      initialPlans={props.initialPlans}
-      initialCursor={props.initialCursor}
-    />
+    <HydrationBoundary state={dehydratedState}>
+      <Home />
+    </HydrationBoundary>
   );
 }
 
@@ -21,24 +25,16 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
   try {
     const cookie = req.headers.cookie || '';
     const isLoggedIn = !!cookie.includes('accessToken');
+    const queryClient = new QueryClient();
 
-    const res = await ssrInstance(cookie).get<PlanListResponse>(
-      `/api/plans?size=10&sort=default`,
-      {
-        headers: isLoggedIn ? { Cookie: cookie } : {},
-        withCredentials: isLoggedIn,
-      },
-    );
+    await queryClient.prefetchQuery({
+      queryKey: ['plans'],
+      queryFn: () => getPlans({ cookie, isLoggedIn }),
+    });
 
-    const data = res.data;
-    const initialPlans: PlanDataWithCategory[] = data.data.planList.map(
-      (item) => ({ ...item }),
-    );
-    const nextCursor = data.data.nextCursor;
     return {
       props: {
-        initialPlans,
-        initialCursor: nextCursor !== undefined ? nextCursor : null,
+        dehydratedState: dehydrate(queryClient),
       },
     };
   } catch (error) {

--- a/pages/plans/index.tsx
+++ b/pages/plans/index.tsx
@@ -27,9 +27,20 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
     const isLoggedIn = !!cookie.includes('accessToken');
     const queryClient = new QueryClient();
 
-    await queryClient.prefetchQuery({
-      queryKey: ['plans'],
-      queryFn: () => getPlans({ cookie, isLoggedIn }),
+    const [sortParam, categoryParam] = ['', 1];
+
+    await queryClient.prefetchInfiniteQuery({
+      queryKey: ['plans', { sortParam, categoryParam }],
+      queryFn: ({ pageParam }) => {
+        return getPlans({
+          sortParam,
+          categoryParam,
+          cookie,
+          isLoggedIn,
+          pageParam,
+        });
+      },
+      initialPageParam: null,
     });
 
     return {

--- a/src/pages/app/plans/api/getPlans.ts
+++ b/src/pages/app/plans/api/getPlans.ts
@@ -1,0 +1,36 @@
+import { PlanListResponse } from '@/shared/types/plans';
+import csrInstance from '@/shared/utils/axios';
+import { ssrInstance } from '@/shared/utils/axiosSsr';
+
+export interface getPlansProps {
+  cookie?: string;
+  isLoggedIn?: boolean;
+  sortParam?: string;
+  categoryParam?: number;
+  cursorParam?: string;
+}
+
+async function getPlans({
+  cookie = '',
+  isLoggedIn = false,
+  sortParam = '',
+  categoryParam = 1,
+  cursorParam = '',
+}: getPlansProps) {
+  const instance =
+    typeof window === 'undefined' ? ssrInstance(cookie) : csrInstance;
+
+  const res = await instance.get<PlanListResponse>(
+    `/api/plans?size=10&sort=${sortParam}&categoryId=${categoryParam}&cursor=${cursorParam}`,
+    {
+      headers: isLoggedIn ? { Cookie: cookie } : {},
+      withCredentials: isLoggedIn,
+    },
+  );
+
+  const data = res.data;
+
+  return data;
+}
+
+export default getPlans;

--- a/src/pages/app/plans/api/getPlans.ts
+++ b/src/pages/app/plans/api/getPlans.ts
@@ -1,6 +1,7 @@
 import { PlanListResponse } from '@/shared/types/plans';
 import csrInstance from '@/shared/utils/axios';
 import { ssrInstance } from '@/shared/utils/axiosSsr';
+import { API_PATHS } from '@/shared/constants/apiPath';
 
 export interface getPlansProps {
   cookie?: string;
@@ -20,8 +21,10 @@ async function getPlans({
   const instance =
     typeof window === 'undefined' ? ssrInstance(cookie) : csrInstance;
 
+  const queryParams = `size=10${sortParam ? `&sortParam=${sortParam}` : ''}${categoryParam ? `&categoryId=${categoryParam}` : ''}${cursorParam ? `&cursor=${cursorParam}` : ''}`;
+
   const res = await instance.get<PlanListResponse>(
-    `/api/plans?size=10${sortParam ? `&sortParam=${sortParam}` : ''}${categoryParam ? `&categoryId=${categoryParam}` : ''}${cursorParam ? `&cursor=${cursorParam}` : ''}`,
+    API_PATHS.PLAN.GET_ALL(queryParams),
     {
       headers: isLoggedIn ? { Cookie: cookie } : {},
       withCredentials: isLoggedIn,

--- a/src/pages/app/plans/api/getPlans.ts
+++ b/src/pages/app/plans/api/getPlans.ts
@@ -21,15 +21,16 @@ async function getPlans({
   const instance =
     typeof window === 'undefined' ? ssrInstance(cookie) : csrInstance;
 
-  const queryParams = `size=10${sortParam ? `&sortParam=${sortParam}` : ''}${categoryParam ? `&categoryId=${categoryParam}` : ''}${cursorParam ? `&cursor=${cursorParam}` : ''}`;
-
-  const res = await instance.get<PlanListResponse>(
-    API_PATHS.PLAN.GET_ALL(queryParams),
-    {
-      headers: isLoggedIn ? { Cookie: cookie } : {},
-      withCredentials: isLoggedIn,
+  const res = await instance.get<PlanListResponse>(API_PATHS.PLAN.GET_ALL, {
+    headers: isLoggedIn ? { Cookie: cookie } : {},
+    withCredentials: isLoggedIn,
+    params: {
+      size: 10,
+      ...(cursorParam && { cursor: cursorParam }),
+      ...(categoryParam && { categoryId: categoryParam }),
+      ...(sortParam && { sort: sortParam }),
     },
-  );
+  });
 
   const data = res.data;
 

--- a/src/pages/app/plans/api/getPlans.ts
+++ b/src/pages/app/plans/api/getPlans.ts
@@ -8,7 +8,7 @@ export interface getPlansProps {
   isLoggedIn?: boolean;
   sortParam?: string;
   categoryParam?: number;
-  pageParam?: number;
+  pageParam?: number | null;
 }
 
 async function getPlans({
@@ -16,7 +16,7 @@ async function getPlans({
   isLoggedIn = false,
   sortParam = '',
   categoryParam = 1,
-  pageParam: cursorParam = 0,
+  pageParam: cursorParam = null,
 }: getPlansProps) {
   const instance =
     typeof window === 'undefined' ? ssrInstance(cookie) : csrInstance;
@@ -31,7 +31,6 @@ async function getPlans({
       ...(sortParam && { sort: sortParam }),
     },
   });
-  console.log(res, '--res---');
 
   const data = res.data;
 

--- a/src/pages/app/plans/api/getPlans.ts
+++ b/src/pages/app/plans/api/getPlans.ts
@@ -8,7 +8,7 @@ export interface getPlansProps {
   isLoggedIn?: boolean;
   sortParam?: string;
   categoryParam?: number;
-  cursorParam?: string;
+  pageParam?: number;
 }
 
 async function getPlans({
@@ -16,7 +16,7 @@ async function getPlans({
   isLoggedIn = false,
   sortParam = '',
   categoryParam = 1,
-  cursorParam = '',
+  pageParam: cursorParam = 0,
 }: getPlansProps) {
   const instance =
     typeof window === 'undefined' ? ssrInstance(cookie) : csrInstance;
@@ -31,6 +31,7 @@ async function getPlans({
       ...(sortParam && { sort: sortParam }),
     },
   });
+  console.log(res, '--res---');
 
   const data = res.data;
 

--- a/src/pages/app/plans/api/getPlans.ts
+++ b/src/pages/app/plans/api/getPlans.ts
@@ -21,7 +21,7 @@ async function getPlans({
     typeof window === 'undefined' ? ssrInstance(cookie) : csrInstance;
 
   const res = await instance.get<PlanListResponse>(
-    `/api/plans?size=10&sort=${sortParam}&categoryId=${categoryParam}&cursor=${cursorParam}`,
+    `/api/plans?size=10${sortParam ? `&sortParam=${sortParam}` : ''}${categoryParam ? `&categoryId=${categoryParam}` : ''}${cursorParam ? `&cursor=${cursorParam}` : ''}`,
     {
       headers: isLoggedIn ? { Cookie: cookie } : {},
       withCredentials: isLoggedIn,

--- a/src/pages/app/plans/index.tsx
+++ b/src/pages/app/plans/index.tsx
@@ -16,6 +16,16 @@ export const Home = () => {
     select: (data) => data.data,
   });
 
+  // const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  //   useInfiniteQuery({
+  //     queryKey: ['plans'],
+  //     queryFn: ({ pageParam = undefined }) =>
+  //       getPlans({ cursorParam: pageParam }),
+  //     initialPageParam: undefined, // 보통 cursor 기반은 undefined로 시작
+  //     getNextPageParam: (lastPage) => lastPage.data.nextCursor,
+  //   });
+
+  // console.log(data, '--dataa--');
   // 일정 데이터 상태관리
   const [plans, setPlans] = useState<PlanDataWithCategory[]>(
     () => data?.planList ?? [],

--- a/src/pages/app/plans/model/type.ts
+++ b/src/pages/app/plans/model/type.ts
@@ -1,0 +1,6 @@
+import { PlanListResponse } from '@/shared/types/plans';
+
+export interface planInfiniteQueryResponseType {
+  pageParam: number[];
+  pages: PlanListResponse[];
+}

--- a/src/pages/app/plans/model/useCursorInfiniteScrollPlans.tsx
+++ b/src/pages/app/plans/model/useCursorInfiniteScrollPlans.tsx
@@ -23,15 +23,11 @@ interface UseCursorInfiniteScrollProps {
 
 export const useCursorInfiniteScroll = ({
   selectedCategory,
-  selectedSubCategory,
   selectedSort,
 }: UseCursorInfiniteScrollProps) => {
   const isLoggedIn = useSelector((state: RootState) => state.auth.isLoggedIn);
   const loaderRef = useRef<HTMLDivElement | null>(null);
   const observerRef = useRef<IntersectionObserver | null>(null);
-
-  // 요청한 cursor를 저장하여 중복 요청 방지
-  const requestedCursors = useRef(new Set<number | null | undefined>());
 
   const sortParam = selectedSort ? `${selectedSort.value}` : '';
   const categoryParam = getCategoryId(selectedCategory || '');
@@ -79,6 +75,7 @@ export const useCursorInfiniteScroll = ({
    */
   useEffect(() => {
     if (!selectedCategory) return;
+
     if (!hasNextPage) {
       if (observerRef.current) {
         observerRef.current.disconnect();
@@ -102,24 +99,6 @@ export const useCursorInfiniteScroll = ({
       }
     };
   }, [hasNextPage, handleObserver, selectedCategory]);
-
-  /**
-   * 정렬 필터 변경 시 requestedCursors 초기화
-   */
-  useEffect(() => {
-    if (selectedSort) {
-      requestedCursors.current.clear();
-    }
-  }, [selectedSort]);
-
-  /**
-   * 카테고리 변경 시 requestedCursors 초기화
-   */
-  useEffect(() => {
-    if (selectedCategory || selectedSubCategory) {
-      requestedCursors.current.clear();
-    }
-  }, [selectedCategory, selectedSubCategory]);
 
   return { loaderRef, data, isFetchingNextPage, hasNextPage };
 };

--- a/src/pages/app/plans/model/useCursorInfiniteScrollPlans.tsx
+++ b/src/pages/app/plans/model/useCursorInfiniteScrollPlans.tsx
@@ -49,7 +49,15 @@ export const useCursorInfiniteScroll = ({
           isLoggedIn,
         }),
       initialPageParam: null,
-      getNextPageParam: (lastPage) => lastPage.data.nextCursor ?? null,
+      getNextPageParam: (lastPage) => {
+        if (lastPage.data.nextCursor === null) {
+          if (observerRef.current) {
+            observerRef.current.disconnect();
+          }
+        }
+
+        return lastPage.data.nextCursor ?? null;
+      },
     });
 
   /**

--- a/src/pages/app/plans/model/useCursorInfiniteScrollPlans.tsx
+++ b/src/pages/app/plans/model/useCursorInfiniteScrollPlans.tsx
@@ -42,7 +42,7 @@ export const useCursorInfiniteScroll = ({
       Error,
       planInfiniteQueryResponseType,
       (string | { sortParam: string; categoryParam: number })[],
-      number
+      number | null
     >({
       queryKey: ['plans', { sortParam, categoryParam }],
       queryFn: ({ pageParam }) =>
@@ -52,7 +52,7 @@ export const useCursorInfiniteScroll = ({
           categoryParam,
           isLoggedIn,
         }),
-      initialPageParam: 0,
+      initialPageParam: null,
       getNextPageParam: (lastPage) => lastPage.data.nextCursor ?? null,
     });
 

--- a/src/pages/app/plans/model/useCursorInfiniteScrollPlans.tsx
+++ b/src/pages/app/plans/model/useCursorInfiniteScrollPlans.tsx
@@ -50,7 +50,7 @@ export const useCursorInfiniteScroll = ({
     async (entries: IntersectionObserverEntry[]) => {
       const target = entries[0];
 
-      if (target.isIntersecting && !isFetching && cursor !== null) {
+      if (target.isIntersecting && !isFetching && cursor) {
         // 이미 요청한 cursor인지 확인하여 중복 요청 방지
         if (requestedCursors.current.has(cursor)) return;
 
@@ -115,6 +115,7 @@ export const useCursorInfiniteScroll = ({
     const observer = new IntersectionObserver(handleObserver, {
       threshold: 0.1,
     });
+
     observerRef.current = observer;
     if (loaderRef.current) {
       observer.observe(loaderRef.current);

--- a/src/shared/constants/apiPath.ts
+++ b/src/shared/constants/apiPath.ts
@@ -25,7 +25,7 @@ export const API_PATHS = {
   },
   PLAN: {
     CREATE: (meetingId: number) => `/api/plans/${meetingId}`,
-    GET_ALL: (params: string) => `/api/plans?${params}`,
+    GET_ALL: `/api/plans`,
     GET_DETAIL: (planId: number) => `/api/plans/${planId}`,
     CANCEL: (planId: number) => `/api/plans/${planId}/cancel`,
     ATTEND: (planId: number) => `/api/plans/${planId}/attendance`,

--- a/src/shared/constants/gnb.ts
+++ b/src/shared/constants/gnb.ts
@@ -8,7 +8,7 @@ export const menuItems = [
   {
     name: '모든 리뷰',
     key: 2,
-    path: '/all-reviews',
+    path: '/reviews',
     icon: GNBReviewIcon,
   },
   {


### PR DESCRIPTION
## 📝 작업 내용
이슈: #208 

- 기존 `axios`를 통해 클라이언트 측 일정 목록 데이터 요청(무한 스크롤) -> `useInfiniteQuery`로 전환

- `useInfiniteQuery`로 전환하면서 `getServerSideProps` 함수를 통해 `props`로 전달 받던 `initialData` -> `prefetchInfiniteQuery`로 전환

- `Home` 컴포넌트에 존재하던 `localState(isFetching, cursor, plans)` 상태를 리액트 쿼리로 관리합니다. 

- 필터 적용 시, 잘 동작하는지 테스트해보고 수정 사항 있으면 PR 올리겠습니다. 

## 이미지 자료
<img width="1533" alt="image" src="https://github.com/user-attachments/assets/09152b1c-4001-42db-b29f-0504377d725f" />
<img width="1296" alt="image" src="https://github.com/user-attachments/assets/0e9b1fbb-a803-4b8b-b4dd-01400489c36b" />
